### PR TITLE
configure bot token as environment var for local runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+credentials.json
+token.pickle

--- a/bot.py
+++ b/bot.py
@@ -498,4 +498,4 @@ def get_name_from_args(args):
 
 sheets = SheetTransformer()
 lab_hours_reminder.start()
-client.run(BOT_TOKEN)
+client.run(SPARKIEEE_TOKEN)

--- a/creds.py
+++ b/creds.py
@@ -1,4 +1,6 @@
-BOT_TOKEN = 'Your bot token here'
+import os
+
+SPARKIEEE_TOKEN = os.getenv("SPARKIEEE_TOKEN")
 LAB_CHANNEL_ID = 724325916154658867
 
 PROJECTS = {

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Run the following command to install the Google Client library:
 pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
 ```
 
-Follow the directions under the "Prerequisites" section in the Google Sheets API Python Quickstart Guide [here](https://developers.google.com/sheets/api/quickstart/python) to generate a `credentials.json` file. You'll need to [create a Google Cloud Platform project](https://developers.google.com/workspace/guides/create-project) and enable the Google Sheets API. Then you'll need to [generate credentials](https://developers.google.com/workspace/guides/create-credentials). Follow the directions to [generate a credentials.json file](https://developers.google.com/workspace/guides/create-credentials#web) for a Web application. Drag it into the root directory.
+Follow the directions under the "Prerequisites" section in the Google Sheets API Python Quickstart Guide [here](https://developers.google.com/sheets/api/quickstart/python) to generate a `credentials.json` file. You'll need to [create a Google Cloud Platform project](https://developers.google.com/workspace/guides/create-project) and enable the Google Sheets API. Then you'll need to [generate credentials](https://developers.google.com/workspace/guides/create-credentials). Follow the directions to [generate a credentials json file](https://developers.google.com/workspace/guides/create-credentials#web) for a Desktop application. Rename it to `credentials.json` and drag it into the root directory.
 
 To generate a pickle file that allows the bot access to your account to read/write to Google Sheets, run the `bot.py` script. 
 
@@ -28,7 +28,13 @@ To create the Discord bot account, use the Discord developer portal to generate 
 
 ## Testing 
 
-To deploy the bot locally, insert your Bot Token in `creds.py` and run `bot.py`:
+To deploy the bot locally, set the `SPARKIEEE_TOKEN` environment variable to the Discord bot token you generated:
+
+```
+export SPARKIEEE_TOKEN=<DISCORD BOT TOKEN HERE>
+```
+
+Run `bot.py`:
 
 ```
 python3 bot.py


### PR DESCRIPTION
- Instead of having users manually set the `SPARKIEEE_TOKEN` var when locally running the bot, they now run `export SPARKIEEE_TOKEN=""` instead
- This allows for more generic configuration in Heroku, where we can set env variable
- Updated outdated setup documentation
- Added gitignore