### PR TITLE
Added functionality to checkoff command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -291,7 +291,11 @@ async def checkoff(ctx, *args):
             # try:
             # All arguments including the third arg and after are counted as the name
             name = get_name_from_args(args[2:])
-            old_val = sheets.checkoff(info["SPREAD_ID"], assignment=args[1], name=name, val=new_val)
+            try:
+                old_val = sheets.checkoff(info["SPREAD_ID"], assignment=args[1], name=name, val=new_val)
+            except Exception as e:
+                await ctx.send(e)
+                return
             if old_val == 'x':
                 msg = f'**{name}** has already been checked off for **{args[0]} {args[1]}**.\n'
             else:

--- a/sheet_transformer.py
+++ b/sheet_transformer.py
@@ -99,11 +99,33 @@ class SheetTransformer:
 
         old_val = ''
         member_row = None
+        # If have same first name, consider them near match
+        near_matches = []
+        member_first_name = name.split(' ')[0].upper().strip()
+
         for row, r in enumerate(values):
             if r[0].upper().strip() == name.upper().strip():
                 member_row = row + 1
+                break
+
+            # Store person with same first name into array
+            matched_first_name = r[0].split(' ')[0].upper().strip()
+            if matched_first_name.startswith(member_first_name):
+                near_matches.append(r[0])
+
         if member_row == None:
-            raise Exception(f'Error, project member **{name}** not found.')
+            # Base error message
+            err_msg = f'Error, project member {name} not found.'
+
+            # Format near matches to a string
+            near_matches_as_str = 'Here are the closest matches:\n```'
+            if len(near_matches) > 0:
+                # Go through each, separate with a new line
+                for match in near_matches:
+                    near_matches_as_str += match + '\n'
+                # Add it to the base error message
+                err_msg += '\n' + near_matches_as_str + '\n```'
+            raise Exception(err_msg)
 
         assignment_col = None
         for col, a in enumerate(values[0]):


### PR DESCRIPTION
Previous functionality had to provide the correct name as matched in the roster with feedback. Added near_matches functionality to checkoff so that officers don't have to know the correct member name on hand as it matches the roster

Similar to status and lookup, it will search for nearest matches starting with the first name given in the argument